### PR TITLE
Feature/Test: User Authentication and Tests Using RSpec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,9 @@ gem 'bootsnap', require: false
 # Use SendGrid for sending emails
 gem 'sendgrid-ruby'
 
+# Use JWT for authentication
+gem 'jwt'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri windows]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,6 +129,7 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     json (2.6.3)
+    jwt (1.5.6)
     language_server-protocol (3.17.0.3)
     loofah (2.22.0)
       crass (~> 1.0.2)
@@ -316,6 +317,7 @@ DEPENDENCIES
   factory_bot_rails
   importmap-rails
   jbuilder
+  jwt
   pg (>= 0.18, < 2.0)
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.2)

--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -18,16 +18,15 @@ class AuthController < ApplicationController
   before_action :authenticate!, only: %i[destroy]
   before_action :do_not_authenticate!, except: %i[destroy]
 
-  def new
-    pp session
-    pp cookies
-  end
+  def new; end
 
   def create
     unless user&.authenticate(auth_params[:password])
       return redirect_to new_auth_url,
                          alert: 'Invalid email or password'
     end
+
+    return redirect_to new_auth_url, alert: 'Account not active' unless user.active?
 
     payload = { user_id: user.id }
     token = JwtService.encode(payload)

--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AuthController < ApplicationController
+  def new; end
+
+  def create; end
+
+  def destroy; end
+end

--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -1,9 +1,48 @@
 # frozen_string_literal: true
 
 class AuthController < ApplicationController
+  include UserSettable
+  include Authenticable
+
+  before_action lambda {
+                  self.action_to_user_finder = {
+                    create: User.method(:find_by_email)
+                  }
+                },
+                lambda {
+                  self.action_to_user_args = {
+                    create: { args: [auth_params[:email]], kwargs: {} }
+                  }
+                }, :set_user, only: %i[create]
+
+  before_action :authenticate!, only: %i[destroy], unless: -> { :request.referrer.present? }
+  before_action :do_not_authenticate!, except: %i[destroy]
+
   def new; end
 
-  def create; end
+  def create
+    unless user&.authenticate(auth_params[:password])
+      return redirect_to new_auth_url,
+                         alert: 'Invalid email or password'
+    end
 
-  def destroy; end
+    payload = { user_id: user.id }
+    token = JwtService.encode(payload)
+    cookies[:jwt] = { value: token, httponly: true }
+    self.current_user = user
+
+    redirect_to root_url, notice: 'Logged in successfully'
+  end
+
+  def destroy
+    session.delete(:current_user)
+    cookies.delete(:jwt)
+    redirect_to new_auth_url, notice: 'Logged out successfully'
+  end
+
+  private
+
+  def auth_params
+    params.permit(:email, :password)
+  end
 end

--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -15,10 +15,13 @@ class AuthController < ApplicationController
                   }
                 }, :set_user, only: %i[create]
 
-  before_action :authenticate!, only: %i[destroy], unless: -> { :request.referrer.present? }
+  before_action :authenticate!, only: %i[destroy]
   before_action :do_not_authenticate!, except: %i[destroy]
 
-  def new; end
+  def new
+    pp session
+    pp cookies
+  end
 
   def create
     unless user&.authenticate(auth_params[:password])

--- a/app/controllers/concerns/authenticable.rb
+++ b/app/controllers/concerns/authenticable.rb
@@ -16,7 +16,7 @@ module Authenticable
   end
 
   def do_not_authenticate!
-    redirect_to root_url unless current_user.nil? && cookies.key?(:jwt)
+    redirect_to root_url if current_user.present? || cookies.key?(:jwt)
   end
 
   def current_user

--- a/app/controllers/concerns/authenticable.rb
+++ b/app/controllers/concerns/authenticable.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Authenticable
+  extend ActiveSupport::Concern
+
+  private
+
+  def authenticate!
+    return unless current_user.nil?
+
+    token = cookies[:jwt]
+    user_id = JwtService.decode(token)['user_id']
+    self.current_user = User.find(user_id)
+  rescue JWT::DecodeError || JWT::ExpiredSignature
+    redirect_to new_auth_url, alert: 'You must be logged in to access this page'
+  end
+
+  def do_not_authenticate!
+    redirect_to root_url unless current_user.nil? && cookies.key?(:jwt)
+  end
+
+  def current_user
+    session[:current_user]
+  end
+
+  def current_user=(user)
+    session[:current_user] = user
+  end
+end

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -2,11 +2,14 @@
 
 class ConfirmationsController < ApplicationController
   include UserSettable
+  include Authenticable
 
   before_action :set_action_to_user_finder, :set_action_to_user_args
   before_action only: %i[show create] do
     set_user { |finder, args| finder.call(*args[:args], **args[:kwargs]) }
   end
+
+  before_action :do_not_authenticate!
 
   def show
     return flash.now[:alert] = 'Account confirmation failed' if user.nil?

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -3,7 +3,9 @@
 class HomeController < ApplicationController
   def index; end
 
-  def login; end
+  def login
+    redirect_to new_auth_url
+  end
 
   def signup
     redirect_to new_user_url

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,11 +2,15 @@
 
 class UsersController < ApplicationController
   include UserSettable
+  include Authenticable
 
   before_action :set_action_to_user_finder, :set_action_to_user_args
   before_action except: %i[index] do
     set_user { |finder, args| finder.call(*args[:args], **args[:kwargs]) }
   end
+
+  before_action :authenticate!, except: %i[new create]
+  before_action :do_not_authenticate!, only: %i[new create]
 
   attr_accessor :users
 

--- a/app/helpers/auth_helper.rb
+++ b/app/helpers/auth_helper.rb
@@ -1,0 +1,2 @@
+module AuthHelper
+end

--- a/app/services/jwt_service.rb
+++ b/app/services/jwt_service.rb
@@ -3,8 +3,9 @@
 class JwtService
   SECRET = Rails.application.secrets.secret_key_base
   ALGORITHM = 'HS256'
+  JWT_EXPIRES_IN = 24.hours.from_now
 
-  def self.encode(payload, exp = 24.hours.from_now)
+  def self.encode(payload, exp = JWT_EXPIRES_IN)
     payload['exp'] = exp.to_i
     JWT.encode(payload, SECRET, ALGORITHM)
   end

--- a/app/services/jwt_service.rb
+++ b/app/services/jwt_service.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class JwtService
+  SECRET = Rails.application.secrets.secret_key_base
+  ALGORITHM = 'HS256'
+
+  def self.encode(payload)
+    JWT.encode(payload, SECRET, ALGORITHM)
+  end
+
+  def self.decode(token)
+    JWT.decode(token, SECRET, true, algorithm: ALGORITHM).first
+  end
+end

--- a/app/services/jwt_service.rb
+++ b/app/services/jwt_service.rb
@@ -4,7 +4,8 @@ class JwtService
   SECRET = Rails.application.secrets.secret_key_base
   ALGORITHM = 'HS256'
 
-  def self.encode(payload)
+  def self.encode(payload, exp = 24.hours.from_now)
+    payload['exp'] = exp.to_i
     JWT.encode(payload, SECRET, ALGORITHM)
   end
 

--- a/app/views/application/_auth_info.html.erb
+++ b/app/views/application/_auth_info.html.erb
@@ -1,0 +1,6 @@
+<% if session[:current_user] %>
+  <div style="position: fixed; top: 10px; right: 10px; display: flex; align-items: center; justify-content: space-between;">
+    <p style="margin: 0 10px 0 0;"><%= link_to session[:current_user]['first_name'], user_path(session[:current_user]['id']) %></p>
+    <%= button_to 'Logout', auth_path, method: :delete, style: "background-color: red; color: white; border: none; padding: 6px 12px; text-transform: uppercase; letter-spacing: 0.5px; transition: all 0.3s ease 0s; cursor: pointer;" %>
+  </div>
+<% end %>

--- a/app/views/application/_auth_info.html.erb
+++ b/app/views/application/_auth_info.html.erb
@@ -1,6 +1,6 @@
 <% if session[:current_user] %>
   <div style="position: fixed; top: 10px; right: 10px; display: flex; align-items: center; justify-content: space-between;">
     <p style="margin: 0 10px 0 0;"><%= link_to session[:current_user]['first_name'], user_path(session[:current_user]['id']) %></p>
-    <%= button_to 'Logout', auth_path, method: :delete, style: "background-color: red; color: white; border: none; padding: 6px 12px; text-transform: uppercase; letter-spacing: 0.5px; transition: all 0.3s ease 0s; cursor: pointer;" %>
+    <%= button_to 'Logout', auth_path, method: :delete, style: "background-color: red; color: white; border: none; padding: 12px 24px; letter-spacing: 0.5px; transition: all 0.3s ease 0s; cursor: pointer;" %>
   </div>
 <% end %>

--- a/app/views/auth/_form.html.erb
+++ b/app/views/auth/_form.html.erb
@@ -1,0 +1,14 @@
+<%= form_with(url: auth_path, method: :post, local: true) do |form| %>
+  <div style="margin-bottom: 1em;">
+    <%= form.label :email, style: "font-size: 1.2em; color: #333;" %>
+    <%= form.text_field :email, style: "width: 100%; padding: 0.5em; font-size: 1em;" %>
+  </div>
+
+  <div style="margin-bottom: 1em;">
+    <%= form.label :password, style: "font-size: 1.2em; color: #333;" %>
+    <%= form.password_field :password, style: "width: 100%; padding: 0.5em; font-size: 1em;" %>
+  </div>
+
+
+  <%= form.submit "Login", style: "background-color: #4CAF50; color: white; padding: 1em 2em; border: none; cursor: pointer;" %>
+<% end %>

--- a/app/views/auth/new.html.erb
+++ b/app/views/auth/new.html.erb
@@ -1,0 +1,13 @@
+<div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px; box-sizing: border-box; background-color: #f8f9fa; border-radius: 10px; box-shadow: 0 2px 5px rgba(0, 0, 0, 0.15);">
+  <h1 style="text-align: center; color: #4CAF50; font-size: 2em; margin-bottom: 20px;">Log In</h1>
+
+  <h2 style="text-align: center; color: #333; font-size: 1.5em; margin-bottom: 20px;">Please enter your email and password</h2>
+
+  <%= render "form" %>
+
+  <br>
+
+  <div style="text-align: center; margin-top: 20px;">
+    <%= link_to "Back", root_path, style: "color: #4CAF50; text-decoration: none; border-bottom: 1px solid #4CAF50;" %>
+  </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,7 @@
   </head>
 
   <body>
+    <%= render 'auth_info' %>
     <%= render 'flash' %>
     <%= yield %>
   </body>

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,8 @@
-require_relative "boot"
+# frozen_string_literal: true
 
-require "rails/all"
+require_relative 'boot'
+
+require 'rails/all'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -14,7 +16,7 @@ module AppointmentScheduler
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.
-    config.autoload_lib(ignore: %w(assets tasks))
+    config.autoload_lib(ignore: %w[assets tasks])
 
     # Load the .env file in development and test environments
     Dotenv::Rails.load if %w[development test].include? Rails.env
@@ -26,5 +28,8 @@ module AppointmentScheduler
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    # Autoload `app/services` folder
+    config.autoload_paths << Rails.root.join('app/services')
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,9 @@ Rails.application.routes.draw do
   # Confirmations
   resources :confirmations, only: %i[new create show], param: :token
 
+  # Authentication
+  resource :auth, controller: :auth, only: %i[new create destroy]
+
   # Defines the root path route ("/")
   root to: redirect('/home/index')
 end

--- a/docs/sequences/user_authentication_sequence.md
+++ b/docs/sequences/user_authentication_sequence.md
@@ -1,0 +1,51 @@
+# User Authentication Sequence
+```mermaid
+sequenceDiagram
+    participant User
+    participant Server
+    participant Database
+    
+    User->>Server: Sends email and password
+    Server->>Database: Retrieves user by email
+    alt User not found
+        Database->>Server: No user found
+        Server->>User: Error: Invalid email or password [END]
+    else User found
+        Server->>Server: Checks password
+        alt Password incorrect
+            Server->>User: Error: Invalid email or password [END]
+        else Password correct
+            Server->>Server: Checks user status
+            alt User not active
+                Server->>User: Error: Account not active [END]
+            else User active
+                Server->>Server: Generates JWT token
+                Server->>User: Sends JWT token as cookie
+            end
+        end
+    end
+```
+
+# Subsequent Requests Sequence
+```mermaid
+sequenceDiagram
+    participant User
+    participant Server
+    participant Database
+    
+    User->>Server: Sends request with JWT token
+    Server->>Server: Decodes JWT token
+    alt Token invalid or expired
+        Server->>User: Error: Invalid or expired token [END]
+    else Token valid
+        Server->>Database: Retrieves user by id from token
+        alt User not found
+            Database->>Server: No user found
+            Server->>User: Error: User not found [END]
+        else User found
+            Database->>Server: User data
+            Server->>Server: Processes request
+            Server->>User: Sends response
+        end     
+    end
+```

--- a/spec/controllers/auth_controller_spec.rb
+++ b/spec/controllers/auth_controller_spec.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require 'factory_bot'
+require 'rails_helper'
+
+RSpec.describe AuthController, type: :controller do
+  let!(:user_jane_doe) { FactoryBot.create(:user_jane_doe) }
+
+  context 'GET #new when not authenticated' do
+    before do
+      get :new
+    end
+
+    it 'should return success response' do
+      expect(response).to be_successful
+    end
+
+    it 'should render the new template' do
+      expect(response).to render_template(:new)
+    end
+  end
+
+  context 'GET #new when already authenticated' do
+    it 'should redirect to root_url' do
+      allow(controller).to receive(:current_user).and_return(user_jane_doe)
+      get :new
+      expect(response).to redirect_to(root_url)
+    end
+  end
+
+  context 'POST #create with invalid email' do
+    before do
+      post :create, params: FactoryBot.attributes_for(:user_jane_doe, :inavlid_email_for_login)
+    end
+
+    it 'should return alert message' do
+      expect(flash[:alert]).to eq('Invalid email or password')
+    end
+
+    it 'should redirect to new_auth_url' do
+      expect(response).to redirect_to(new_auth_url)
+    end
+  end
+
+  context 'POST #create with invalid password' do
+    before do
+      post :create, params: FactoryBot.attributes_for(:user_jane_doe, :inavlid_password_for_login)
+    end
+
+    it 'should return alert message' do
+      expect(flash[:alert]).to eq('Invalid email or password')
+    end
+
+    it 'should redirect to new_auth_url' do
+      expect(response).to redirect_to(new_auth_url)
+    end
+  end
+
+  context 'POST #create with inactive user' do
+    before do
+      post :create, params: FactoryBot.attributes_for(:user_jane_doe)
+    end
+
+    it 'should return alert message' do
+      expect(flash[:alert]).to eq('Account not active')
+    end
+
+    it 'should redirect to new_auth_url' do
+      expect(response).to redirect_to(new_auth_url)
+    end
+  end
+
+  context 'POST #create with valid email, password and active user' do
+    before do
+      user_jane_doe.active!
+      post :create, params: FactoryBot.attributes_for(:user_jane_doe)
+    end
+
+    it 'should set current_user' do
+      expect(session[:current_user]).to eq(user_jane_doe)
+    end
+
+    it 'should set jwt cookie' do
+      expect(cookies[:jwt]).to be_present
+    end
+
+    it 'should redirect to root_url' do
+      expect(response).to redirect_to(root_url)
+    end
+  end
+
+  context 'POST #create when already authenticated' do
+    it 'should redirect to root_url' do
+      allow(controller).to receive(:current_user).and_return(user_jane_doe)
+      post :create, params: FactoryBot.attributes_for(:user_jane_doe)
+      expect(response).to redirect_to(root_url)
+    end
+  end
+
+  context 'DELETE #destroy when authenticated' do
+    before do
+      user_jane_doe.active!
+      post :create, params: FactoryBot.attributes_for(:user_jane_doe)
+    end
+
+    it 'should delete current_user' do
+      expect { delete :destroy }.to change { session[:current_user] }.from(user_jane_doe).to(nil)
+    end
+
+    it 'should delete jwt cookie' do
+      expect { delete :destroy }.to change { request.cookie_jar[:jwt] }.from(anything).to(nil)
+    end
+
+    it 'should redirect to new_auth_url' do
+      delete :destroy
+      expect(response).to redirect_to(new_auth_url)
+    end
+  end
+
+  context 'DELETE #destroy when not authenticated' do
+    before do
+      delete :destroy
+    end
+
+    it 'should return alert message' do
+      expect(flash[:alert]).to eq('You must be logged in to access this page')
+    end
+
+    it 'should redirect to new_auth_url' do
+      expect(response).to redirect_to(new_auth_url)
+    end
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -19,6 +19,14 @@ FactoryBot.define do
     trait :missing_first_name do
       first_name { nil }
     end
+
+    trait :inavlid_email_for_login do
+      email { 'invalid_email' }
+    end
+
+    trait :inavlid_password_for_login do
+      password { 'invalid_password' }
+    end
   end
 
   factory :user_john_doe, class: User do

--- a/test/controllers/auth_controller_test.rb
+++ b/test/controllers/auth_controller_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+class AuthControllerTest < ActionDispatch::IntegrationTest
+  test "should get new" do
+    get auth_new_url
+    assert_response :success
+  end
+
+  test "should get create" do
+    get auth_create_url
+    assert_response :success
+  end
+
+  test "should get destroy" do
+    get auth_destroy_url
+    assert_response :success
+  end
+end

--- a/test/services/jwt_service_test.rb
+++ b/test/services/jwt_service_test.rb
@@ -19,4 +19,14 @@ class JwtServiceTest < ActiveSupport::TestCase
     decoded_payload = JwtService.decode(token)
     assert_equal @payload, decoded_payload
   end
+
+  test 'should not decode token if expired' do
+    token = JwtService.encode(@payload, 1.second.ago)
+    assert_raises(JWT::ExpiredSignature) { JwtService.decode(token) }
+  end
+
+  test 'should not decode token if invalid' do
+    token = JwtService.encode(@payload)
+    assert_raises(JWT::DecodeError) { JwtService.decode("#{token}invalid") }
+  end
 end

--- a/test/system/jwt_service_test.rb
+++ b/test/system/jwt_service_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require 'yaml'
+
+class JwtServiceTest < ActiveSupport::TestCase
+  def setup
+    @users = YAML.load_file('test/payloads/users.yml', aliases: true)
+    @payload = @users.fetch('valid_user', {})
+  end
+
+  test 'should encode payload' do
+    token = JwtService.encode(@payload)
+    assert_not_empty token
+  end
+
+  test 'should decode payload' do
+    token = JwtService.encode(@payload)
+    decoded_payload = JwtService.decode(token)
+    assert_equal @payload, decoded_payload
+  end
+end


### PR DESCRIPTION
This Pull Request introduces the User Authentication feature and its corresponding tests using `RSpec`.

## Description

This PR includes the implementation of user authentication using JSON Web Tokens (JWT). Users can log in using their email and password, upon which the server provides a JWT in a cookie. For subsequent requests, the cookie-stored JWT is used to verify the user. When a user logs out, the cookie is cleared.

## Primary Changes
### `app/services/jwt_service.rb`

This file contains a simple service for generating, encoding, verifying and decoding JWTs.

### `app/controllers/auth_controller.rb`

This file includes the `AuthController` which handles the authentication requests. It includes methods for logging in and logging out users.

### `app/controllers/concerns/authenticable.rb`

This file includes the `Authenticable` module which is included in `AuthController`, `UsersController`, and `ConfirmationsController`. It provides methods for authenticating users and managing the current user session.

### `app/views/auth`

This directory contains necessary views (e.g. forms) for authentication

## Demo

[user-auth-login-logout.webm](https://github.com/samin-al-wasee/medical-appointment-scheduler/assets/167951273/da78c1e4-1916-4b7e-b53e-79c829f7009d)

## Testing

The new feature has been tested using RSpec. The tests ensure that the user authentication works as expected and handles edge cases. Check `app/spec/controllers/auth_controller_spec.rb`.

### Results

<pre>
AuthController
  GET #new when not authenticated
✓ should return success response
✓ should render the new template
  GET #new when already authenticated
✓ should redirect to root_url
  POST #create with invalid email
✓ should return alert message
✓ should redirect to new_auth_url
  POST #create with invalid password
✓ should return alert message
✓ should redirect to new_auth_url
  POST #create with inactive user
✓ should return alert message
✓ should redirect to new_auth_url
  POST #create with valid email, password and active user
DEPRECATION WARNING: `Rails.application.secrets` is deprecated in favor of `Rails.application.credentials` and will be removed in Rails 7.2. (called from <class:JwtService> at /home/wasee/medical-appointment-scheduler/app/services/jwt_service.rb:4)
✓ should set current_user
✓ should set jwt cookie
✓ should redirect to root_url
  POST #create when already authenticated
✓ should redirect to root_url
  DELETE #destroy when authenticated
✓ should delete current_user
✓ should delete jwt cookie
✓ should redirect to new_auth_url
  DELETE #destroy when not authenticated
✓ should return alert message
✓ should redirect to new_auth_url

Finished in 0.63654 seconds (files took 2.17 seconds to load)
18 examples, 0 failures
</pre>
