### PR TITLE
Utility: Rake Task for Administrator Creation

### DIFF
--- a/lib/tasks/admin_create.rake
+++ b/lib/tasks/admin_create.rake
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+namespace :admin do
+  desc 'Create an admin user'
+  task create: :environment do
+    admin_info = {
+      first_name: ENV.fetch('ADMIN_FIRST_NAME', nil),
+      last_name: ENV.fetch('ADMIN_LAST_NAME', nil),
+      gender: User.genders[:not_specified],
+      role: User.roles[:admin],
+      date_of_birth: ENV.fetch('ADMIN_DOB', nil),
+      email: ENV.fetch('ADMIN_EMAIL', nil),
+      phone_number: ENV.fetch('ADMIN_PHONE_NO', nil),
+      status: User.statuses[:active],
+      password: ENV.fetch('ADMIN_PASSWORD', nil),
+      password_confirmation: ENV.fetch('ADMIN_PASSWORD', nil)
+    }
+
+    admin = User.new(**admin_info)
+
+    begin
+      admin.save!
+    rescue ActiveRecord::RecordInvalid => e
+      warn "Task Failed: #{e.message} due to the following errors:\n#{admin.errors.full_messages.join("\n")}"
+    end
+  end
+end


### PR DESCRIPTION
This Pull Request introduces a new rake task for creating administrators in the system. The task uses environment variables to fetch the admin data. Here are the key changes:

- A new rake task `admin:create` has been added. This task creates a new user with the admin role. The user data (email, password, etc.) is fetched from environment variables.
- This should be the only way to create users with the `admin` role. This enforcement will be implemented in future updates to ensure system security and integrity.
- The task can be found in `lib/tasks/admin_create.rake` file. 

To run the task, use the following command:

```bash
bundle exec rake admin:create
```
or,
```bash
rails admin:create
```