### PR TITLE
Feature/Partial: User Profiles - Profile Models with Tests Using RSpec

### DIFF
--- a/app/models/doctor_profile.rb
+++ b/app/models/doctor_profile.rb
@@ -1,0 +1,2 @@
+class DoctorProfile < ApplicationRecord
+end

--- a/app/models/doctor_profile.rb
+++ b/app/models/doctor_profile.rb
@@ -1,2 +1,26 @@
+# frozen_string_literal: true
+
 class DoctorProfile < ApplicationRecord
+  enum specialty: { general: 0, pediatric: 1, gynecologist: 2, orthopedic: 3, cardiologist: 4, dermatologist: 5,
+                    neurologist: 6, psychiatrist: 7, dentist: 8, ophthalmologist: 9, oncologist: 10, urologist: 11,
+                    endocrinologist: 12, gastroenterologist: 13, pulmonologist: 14, rheumatologist: 15,
+                    nephrologist: 16, hematologist: 17, allergist: 18, geriatrician: 19, radiologist: 20,
+                    anesthesiologist: 21, surgeon: 22, other: 23 }
+
+  belongs_to :user
+
+  validates :specialty, :chamber_address, presence: true
+  validates :registration_number, :user, presence: true, uniqueness: true
+  validate :user_to_be_a_doctor, :user_not_to_have_a_patient_profile
+
+  private
+
+  def user_to_be_a_doctor
+    errors.add(:user, 'is not a doctor') unless user.doctor?
+  end
+
+  def user_not_to_have_a_patient_profile
+    errors.add(:user, 'already has a patient profile') if user.patient_profile.present?
+  end
+
 end

--- a/app/models/patient_profile.rb
+++ b/app/models/patient_profile.rb
@@ -1,0 +1,2 @@
+class PatientProfile < ApplicationRecord
+end

--- a/app/models/patient_profile.rb
+++ b/app/models/patient_profile.rb
@@ -1,2 +1,19 @@
+# frozen_string_literal: true
+
 class PatientProfile < ApplicationRecord
+  enum blood_group: { not_specified: 0, a_positive: 1, a_negative: 2, b_positive: 3, b_negative: 4, ab_positive: 5,
+                      ab_negative: 6, o_positive: 7, o_negative: 8 }
+
+  belongs_to :user
+
+  validates :blood_group, presence: true
+  validates :height_cm, :weight_kg, presence: true, numericality: { only_integer: true, greater_than: 0 }
+  validates :nid_number, presence: true, uniqueness: true, format: { with: /\A[0-9]{10,17}\z/, allow_blank: true }
+  # validates :user, presence: true, uniqueness: true
+  #
+  # private
+  #
+  # def user_does_not_have_a_doctor_profile
+  #   errors.add(:user, 'already has a doctor profile') if user.doctor_profile.present?
+  # end
 end

--- a/app/models/patient_profile.rb
+++ b/app/models/patient_profile.rb
@@ -9,18 +9,16 @@ class PatientProfile < ApplicationRecord
   validates :blood_group, presence: true
   validates :height_cm, :weight_kg, presence: true, numericality: { only_integer: true, greater_than: 0 }
   validates :nid_number, presence: true, uniqueness: true, format: { with: /\A[0-9]{10,17}\z/, allow_blank: true }
-  validate :user_to_be_a_patient
-  # validates :user, presence: true, uniqueness: true
-  #
-  # private
-  #
-  # def user_does_not_have_a_doctor_profile
-  #   errors.add(:user, 'already has a doctor profile') if user.doctor_profile.present?
-  # end
+  validates :user, presence: true, uniqueness: true
+  validate :user_to_be_a_patient, :user_not_to_have_a_doctor_profile
 
   private
 
   def user_to_be_a_patient
     errors.add(:user, 'is not a patient') unless user.patient?
+  end
+
+  def user_not_to_have_a_doctor_profile
+    errors.add(:user, 'already has a doctor profile') if user.doctor_profile.present?
   end
 end

--- a/app/models/patient_profile.rb
+++ b/app/models/patient_profile.rb
@@ -9,6 +9,7 @@ class PatientProfile < ApplicationRecord
   validates :blood_group, presence: true
   validates :height_cm, :weight_kg, presence: true, numericality: { only_integer: true, greater_than: 0 }
   validates :nid_number, presence: true, uniqueness: true, format: { with: /\A[0-9]{10,17}\z/, allow_blank: true }
+  validate :user_to_be_a_patient
   # validates :user, presence: true, uniqueness: true
   #
   # private
@@ -16,4 +17,10 @@ class PatientProfile < ApplicationRecord
   # def user_does_not_have_a_doctor_profile
   #   errors.add(:user, 'already has a doctor profile') if user.doctor_profile.present?
   # end
+
+  private
+
+  def user_to_be_a_patient
+    errors.add(:user, 'is not a patient') unless user.patient?
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,7 @@ class User < ApplicationRecord
 
   has_secure_password
 
+  has_one :doctor_profile, dependent: :destroy
   has_one :patient_profile, dependent: :destroy
 
   validates :first_name, presence: true, length: { maximum: 128 }
@@ -33,5 +34,9 @@ class User < ApplicationRecord
 
   def full_name
     "#{first_name} #{last_name}"
+  end
+
+  def profile
+    doctor_profile || patient_profile
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,8 @@ class User < ApplicationRecord
 
   has_secure_password
 
+  has_one :patient_profile, dependent: :destroy
+
   validates :first_name, presence: true, length: { maximum: 128 }
   validates :last_name, presence: true, length: { maximum: 128 }
   validates :email, presence: true, uniqueness: true, format: { with: URI::MailTo::EMAIL_REGEXP, allow_blank: true }

--- a/db/migrate/20240430084241_create_patient_profiles.rb
+++ b/db/migrate/20240430084241_create_patient_profiles.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class CreatePatientProfiles < ActiveRecord::Migration[7.1]
+  def change
+    create_table :patient_profiles do |t|
+      t.integer :blood_group, null: false
+      t.integer :height_cm, null: false
+      t.integer :weight_kg, null: false
+      t.text :medical_history
+      t.string :nid_number, null: false
+      t.references :user, null: false, foreign_key: true
+      t.timestamps
+
+      t.unique_constraint [:nid_number], name: 'check_if_nid_number_is_unique'
+      t.unique_constraint [:user_id], name: 'check_if_profile_owner_user_id_is_unique'
+    end
+  end
+end

--- a/db/migrate/20240430113447_create_doctor_profiles.rb
+++ b/db/migrate/20240430113447_create_doctor_profiles.rb
@@ -1,8 +1,16 @@
+# frozen_string_literal: true
+
 class CreateDoctorProfiles < ActiveRecord::Migration[7.1]
   def change
     create_table :doctor_profiles do |t|
-
+      t.integer :specialty, null: false
+      t.text :chamber_address, null: false
+      t.string :registration_number, null: false
+      t.references :user, null: false, foreign_key: true
       t.timestamps
+
+      t.unique_constraint [:registration_number], name: 'check_if_registration_number_is_unique'
+      t.unique_constraint [:user_id], name: 'check_if_profile_owner_doctor_id_is_unique'
     end
   end
 end

--- a/db/migrate/20240430113447_create_doctor_profiles.rb
+++ b/db/migrate/20240430113447_create_doctor_profiles.rb
@@ -1,0 +1,8 @@
+class CreateDoctorProfiles < ActiveRecord::Migration[7.1]
+  def change
+    create_table :doctor_profiles do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,41 +10,54 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 20_240_430_084_241) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_30_113447) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension 'plpgsql'
+  enable_extension "plpgsql"
 
-  create_table 'patient_profiles', force: :cascade do |t|
-    t.integer 'blood_group', null: false
-    t.integer 'height_cm', null: false
-    t.integer 'weight_kg', null: false
-    t.text 'medical_history'
-    t.string 'nid_number', null: false
-    t.bigint 'user_id', null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['user_id'], name: 'index_patient_profiles_on_user_id'
-    t.unique_constraint ['nid_number'], name: 'check_if_nid_number_is_unique'
-    t.unique_constraint ['user_id'], name: 'check_if_profile_owner_user_id_is_unique'
+  create_table "doctor_profiles", force: :cascade do |t|
+    t.integer "specialty", null: false
+    t.text "chamber_address", null: false
+    t.string "registration_number", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_doctor_profiles_on_user_id"
+    t.unique_constraint ["registration_number"], name: "check_if_registration_number_is_unique"
+    t.unique_constraint ["user_id"], name: "check_if_profile_owner_doctor_id_is_unique"
   end
 
-  create_table 'users', force: :cascade do |t|
-    t.string 'first_name', limit: 128, null: false
-    t.string 'last_name', limit: 128, null: false
-    t.integer 'gender', null: false
-    t.date 'date_of_birth', null: false
-    t.integer 'role', null: false
-    t.string 'email', null: false
-    t.string 'phone_number', null: false
-    t.string 'password_digest', null: false
-    t.datetime 'last_login_at'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.integer 'status', default: 0
-
-    t.unique_constraint ['email'], name: 'check_if_email_is_unique'
-    t.unique_constraint ['phone_number'], name: 'check_if_phone_number_is_unique'
+  create_table "patient_profiles", force: :cascade do |t|
+    t.integer "blood_group", null: false
+    t.integer "height_cm", null: false
+    t.integer "weight_kg", null: false
+    t.text "medical_history"
+    t.string "nid_number", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_patient_profiles_on_user_id"
+    t.unique_constraint ["nid_number"], name: "check_if_nid_number_is_unique"
+    t.unique_constraint ["user_id"], name: "check_if_profile_owner_user_id_is_unique"
   end
 
-  add_foreign_key 'patient_profiles', 'users'
+  create_table "users", force: :cascade do |t|
+    t.string "first_name", limit: 128, null: false
+    t.string "last_name", limit: 128, null: false
+    t.integer "gender", null: false
+    t.date "date_of_birth", null: false
+    t.integer "role", null: false
+    t.string "email", null: false
+    t.string "phone_number", null: false
+    t.string "password_digest", null: false
+    t.datetime "last_login_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "status", default: 0
+
+    t.unique_constraint ["email"], name: "check_if_email_is_unique"
+    t.unique_constraint ["phone_number"], name: "check_if_phone_number_is_unique"
+  end
+
+  add_foreign_key "doctor_profiles", "users"
+  add_foreign_key "patient_profiles", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -10,26 +12,41 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_22_111608) do
+ActiveRecord::Schema[7.1].define(version: 20_240_430_084_241) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
+  enable_extension 'plpgsql'
 
-  create_table "users", force: :cascade do |t|
-    t.string "first_name", limit: 128
-    t.string "last_name", limit: 128
-    t.integer "gender", default: 0
-    t.date "date_of_birth"
-    t.integer "role", default: 2
-    t.string "email"
-    t.string "phone_number"
-    t.string "password_digest"
-    t.datetime "last_login_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "status", default: 0
-
-    t.unique_constraint ["email"], name: "check_if_email_is_unique"
-    t.unique_constraint ["phone_number"], name: "check_if_phone_number_is_unique"
+  create_table 'patient_profiles', force: :cascade do |t|
+    t.integer 'blood_group', null: false
+    t.integer 'height_cm', null: false
+    t.integer 'weight_kg', null: false
+    t.text 'medical_history'
+    t.string 'nid_number', null: false
+    t.bigint 'user_id', null: false
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['user_id'], name: 'index_patient_profiles_on_user_id'
+    t.unique_constraint ['nid_number'], name: 'check_if_nid_number_is_unique'
+    t.unique_constraint ['user_id'], name: 'check_if_profile_owner_user_id_is_unique'
   end
 
+  create_table 'users', force: :cascade do |t|
+    t.string 'first_name', limit: 128, null: false
+    t.string 'last_name', limit: 128, null: false
+    t.integer 'gender', null: false
+    t.date 'date_of_birth', null: false
+    t.integer 'role', null: false
+    t.string 'email', null: false
+    t.string 'phone_number', null: false
+    t.string 'password_digest', null: false
+    t.datetime 'last_login_at'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.integer 'status', default: 0
+
+    t.unique_constraint ['email'], name: 'check_if_email_is_unique'
+    t.unique_constraint ['phone_number'], name: 'check_if_phone_number_is_unique'
+  end
+
+  add_foreign_key 'patient_profiles', 'users'
 end

--- a/spec/factories/doctor_profiles.rb
+++ b/spec/factories/doctor_profiles.rb
@@ -1,5 +1,26 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
-  factory :doctor_profile do
-    
+  factory :doctor_profile_jane_doe, class: DoctorProfile do
+    specialty { DoctorProfile.specialties[:general] }
+    chamber_address { 'Dhaka, Bangladesh' }
+    registration_number { '1234567890' }
+    association :user, factory: %i[user_jane_doe role_is_doctor]
+
+    trait :missing_specialty do
+      specialty { nil }
+    end
+
+    trait :missing_chamber_address do
+      chamber_address { nil }
+    end
+
+    trait :missing_registration_number do
+      registration_number { nil }
+    end
+
+    trait :invalid_user_role do
+      association :user, factory: %i[user_jane_doe role_is_patient]
+    end
   end
 end

--- a/spec/factories/doctor_profiles.rb
+++ b/spec/factories/doctor_profiles.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :doctor_profile do
+    
+  end
+end

--- a/spec/factories/patient_profiles.rb
+++ b/spec/factories/patient_profiles.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :patient_profile do
+    
+  end
+end

--- a/spec/factories/patient_profiles.rb
+++ b/spec/factories/patient_profiles.rb
@@ -1,5 +1,36 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
-  factory :patient_profile do
-    
+  factory :patient_profile_jane_doe, class: PatientProfile do
+    blood_group { 'a_positive' }
+    height_cm { 170 }
+    weight_kg { 70 }
+    medical_history { 'No medical history' }
+    nid_number { '1234567890' }
+    association :user, factory: :user_jane_doe
+  end
+
+  trait :missing_blood_group do
+    blood_group { nil }
+  end
+
+  trait :missing_height_cm do
+    height_cm { nil }
+  end
+
+  trait :missing_weight_kg do
+    weight_kg { nil }
+  end
+
+  trait :missing_nid_number do
+    nid_number { nil }
+  end
+
+  trait :invalid_nid_number do
+    nid_number { 'invalid_nid_number' }
+  end
+
+  trait :invalid_user_role do
+    association :user, factory: %i[user_jane_doe role_is_doctor]
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -27,6 +27,10 @@ FactoryBot.define do
     trait :inavlid_password_for_login do
       password { 'invalid_password' }
     end
+
+    trait :role_is_doctor do
+      role { User.roles[:doctor] }
+    end
   end
 
   factory :user_john_doe, class: User do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -31,6 +31,10 @@ FactoryBot.define do
     trait :role_is_doctor do
       role { User.roles[:doctor] }
     end
+
+    trait :role_is_patient do
+      role { User.roles[:patient] }
+    end
   end
 
   factory :user_john_doe, class: User do

--- a/spec/models/doctor_profile_spec.rb
+++ b/spec/models/doctor_profile_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe DoctorProfile, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/doctor_profile_spec.rb
+++ b/spec/models/doctor_profile_spec.rb
@@ -1,5 +1,39 @@
 require 'rails_helper'
 
 RSpec.describe DoctorProfile, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  context 'when doctor profile data is valid' do
+    it 'should be valid' do
+      doctor_profile = FactoryBot.build(:doctor_profile_jane_doe)
+      expect(doctor_profile).to be_valid
+    end
+
+    it 'should belong to the user jane doe' do
+      doctor_profile = FactoryBot.create(:doctor_profile_jane_doe)
+      expect(doctor_profile.user).to eq(User.first)
+    end
+  end
+
+  context 'when doctor profile data is invalid because of missing info' do
+    it 'should be invalid without specialty' do
+      doctor_profile = FactoryBot.build(:doctor_profile_jane_doe, :missing_specialty)
+      expect(doctor_profile).not_to be_valid
+    end
+
+    it 'should be invalid without chamber_address' do
+      doctor_profile = FactoryBot.build(:doctor_profile_jane_doe, :missing_chamber_address)
+      expect(doctor_profile).not_to be_valid
+    end
+
+    it 'should be invalid without registration_number' do
+      doctor_profile = FactoryBot.build(:doctor_profile_jane_doe, :missing_registration_number)
+      expect(doctor_profile).not_to be_valid
+    end
+  end
+
+  context 'when doctor profile data is invalid because of invalid info' do
+    it 'should be invalid with invalid user role' do
+      doctor_profile = FactoryBot.build(:doctor_profile_jane_doe, :invalid_user_role)
+      expect(doctor_profile).not_to be_valid
+    end
+  end
 end

--- a/spec/models/patient_profile_spec.rb
+++ b/spec/models/patient_profile_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe PatientProfile, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/patient_profile_spec.rb
+++ b/spec/models/patient_profile_spec.rb
@@ -1,5 +1,52 @@
+# frozen_string_literal: true
+
+require 'factory_bot'
 require 'rails_helper'
 
 RSpec.describe PatientProfile, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  context 'when patient profile data is valid' do
+    it 'should be valid' do
+      patient_profile = FactoryBot.build(:patient_profile_jane_doe)
+      expect(patient_profile).to be_valid
+    end
+
+    it 'should belong to the user jane doe' do
+      patient_profile = FactoryBot.create(:patient_profile_jane_doe)
+      expect(patient_profile.user).to eq(User.first)
+    end
+  end
+
+  context 'when patient profile data is invalid because of missing info' do
+    it 'should be invalid without blood_group' do
+      patient_profile = FactoryBot.build(:patient_profile_jane_doe, :missing_blood_group)
+      expect(patient_profile).not_to be_valid
+    end
+
+    it 'should be invalid without height_cm' do
+      patient_profile = FactoryBot.build(:patient_profile_jane_doe, :missing_height_cm)
+      expect(patient_profile).not_to be_valid
+    end
+
+    it 'should be invalid without weight_kg' do
+      patient_profile = FactoryBot.build(:patient_profile_jane_doe, :missing_weight_kg)
+      expect(patient_profile).not_to be_valid
+    end
+
+    it 'should be invalid without nid_number' do
+      patient_profile = FactoryBot.build(:patient_profile_jane_doe, :missing_nid_number)
+      expect(patient_profile).not_to be_valid
+    end
+  end
+
+  context 'when patient profile data is invalid because of invalid info' do
+    it 'should be invalid with invalid nid_number' do
+      patient_profile = FactoryBot.build(:patient_profile_jane_doe, :invalid_nid_number)
+      expect(patient_profile).not_to be_valid
+    end
+
+    it 'should be invalid with invalid user role' do
+      patient_profile = FactoryBot.build(:patient_profile_jane_doe, :invalid_user_role)
+      expect(patient_profile).not_to be_valid
+    end
+  end
 end


### PR DESCRIPTION
This Pull Request introduces two new models `DoctorProfile` and `PatientProfile` with factories and `RSpec` specifications.

## Primary Changes
- Creates the `PatientProfile` and `DoctorProfile` models with their respective attributes, validations.
- Generates the corresponding migrations to update the database schema.
- Adds `RSpec` specifications for the `PatientProfile` and `DoctorProfile` models to ensure data validity and integrity.
- Defines factories for the `PatientProfile` and `DoctorProfile` models using `FactoryBot`. This will aid in creating test instances for the specs.

Here are the key files added/updated in this PR:

- `db/migrate/[timestamp]_create_patient_profiles.rb`
- `db/migrate/[timestamp]_create_doctor_profiles.rb`
- `app/models/user.rb`
- `app/models/patient_profile.rb`
- `app/models/doctor_profile.rb`
- `spec/models/patient_profile_spec.rb`
- `spec/models/doctor_profile_spec.rb`
- `spec/factories/users.rb`
- `spec/factories/patient_profiles.rb`
- `spec/factories/doctor_profiles.rb`

Here is the [Updated Schema After Model Creation](https://github.com/wsa-wtag/medical-appointment-scheduler/blob/417ba6e70c7d2b2890dbaf590787bed17d5a3c6e/db/schema.rb)

## Test Results

### `patient_profile_spec.rb`
<pre>
PatientProfile
  when patient profile data is valid
✓ should be valid
✓ should belong to the user jane doe
  when patient profile data is invalid because of missing info
✓ should be invalid without blood_group
✓ should be invalid without height_cm
✓ should be invalid without weight_kg
✓ should be invalid without nid_number
  when patient profile data is invalid because of invalid info
✓ should be invalid with invalid nid_number
✓ should be invalid with invalid user role

Finished in 0.2743 seconds (files took 2.21 seconds to load)
8 examples, 0 failures
</pre>

### `doctor_profile_spec.rb`
<pre>
DoctorProfile
  when doctor profile data is valid
✓ should be valid
✓ should belong to the user jane doe
  when doctor profile data is invalid because of missing info
✓ should be invalid without specialty
✓ should be invalid without chamber_address
✓ should be invalid without registration_number
  when doctor profile data is invalid because of invalid info
✓ should be invalid with invalid user role

Finished in 0.31541 seconds (files took 1.65 seconds to load)
6 examples, 0 failures
</pre>
